### PR TITLE
BUG: MT threads was not set, causing FOD discretization to use all CPUs

### DIFF
--- a/src/config/config_general.cpp
+++ b/src/config/config_general.cpp
@@ -36,8 +36,11 @@ void setDefaultParametersWhenNecessary() {
 		numberOfThreads = MT::maxNumberOfThreads = 1;
 	} else {
 		if (numberOfThreads==NOTSET) {
-            numberOfThreads = MT::maxNumberOfThreads;
+                    numberOfThreads = MT::maxNumberOfThreads;
 		}
+                else {
+                    MT::maxNumberOfThreads = numberOfThreads;
+                }
 	}
 
 	if (timeLimit<=0) {


### PR DESCRIPTION
The tracking uses the number of threads set on the command line (`GENERAL::numberOfThreads`), but the FOD discretization uses `MT::maxNumberOfThreads`, which doesn't get changed from its default of all CPUs. On an HPC cluster, this causes a spike in resource uses, leading to jobs being terminated.